### PR TITLE
Mushroom Cow nerf

### DIFF
--- a/src/main/java/de/hglabor/plugins/hardcoregames/HardcoreGames.java
+++ b/src/main/java/de/hglabor/plugins/hardcoregames/HardcoreGames.java
@@ -7,6 +7,7 @@ import de.hglabor.plugins.hardcoregames.command.StartCommand;
 import de.hglabor.plugins.hardcoregames.config.ConfigKeys;
 import de.hglabor.plugins.hardcoregames.config.HGConfig;
 import de.hglabor.plugins.hardcoregames.game.GameStateManager;
+import de.hglabor.plugins.hardcoregames.game.mechanics.MooshroomCowNerf;
 import de.hglabor.plugins.hardcoregames.game.mechanics.SoupHealing;
 import de.hglabor.plugins.hardcoregames.game.mechanics.Tracker;
 import de.hglabor.plugins.hardcoregames.kit.KitSelectorImpl;
@@ -101,6 +102,7 @@ public final class HardcoreGames extends JavaPlugin {
         pluginManager.registerEvents(new KitEventHandlerImpl(), this);
         pluginManager.registerEvents(new Tracker(), this);
         pluginManager.registerEvents(new SoupHealing(), this);
+        pluginManager.registerEvents(new MooshroomCowNerf(), this);
     }
 
     @Override

--- a/src/main/java/de/hglabor/plugins/hardcoregames/config/ConfigKeys.java
+++ b/src/main/java/de/hglabor/plugins/hardcoregames/config/ConfigKeys.java
@@ -43,4 +43,6 @@ public interface ConfigKeys {
     String MECHANICS = "mechanics";
     String SWORD_DAMAGE_NERF = MECHANICS + "." + "sworddamagemultiplier";
     String OTHER_TOOLS_DAMAGE_NERF = MECHANICS + "." + "othertoolsdamagemultiplier";
+    String MOOSHROOM_COW_NERF_MAXSOUPSFROMCOW = MECHANICS + "." + "maxsoupsfromcow";
+    String MOOSHROOM_COW_NERF_SOUPSINADDITION = MECHANICS + "." + "soupsinaddition"; // For players in Combat
 }

--- a/src/main/java/de/hglabor/plugins/hardcoregames/config/ConfigKeys.java
+++ b/src/main/java/de/hglabor/plugins/hardcoregames/config/ConfigKeys.java
@@ -43,6 +43,6 @@ public interface ConfigKeys {
     String MECHANICS = "mechanics";
     String SWORD_DAMAGE_NERF = MECHANICS + "." + "sworddamagemultiplier";
     String OTHER_TOOLS_DAMAGE_NERF = MECHANICS + "." + "othertoolsdamagemultiplier";
-    String MOOSHROOM_COW_NERF_MAXSOUPSFROMCOW = MECHANICS + "." + "maxsoupsfromcow";
-    String MOOSHROOM_COW_NERF_SOUPSINADDITION = MECHANICS + "." + "soupsinaddition"; // For players in Combat
+    String MOOSHROOM_COW_NERF_MAX_SOUPS_FROM_COW = MECHANICS + "." + "maxsoupsfromcow";
+    String MOOSHROOM_COW_NERF_COMBAT_MULTIPLIER = MECHANICS + "." + "soupsinaddition"; // For players in Combat
 }

--- a/src/main/java/de/hglabor/plugins/hardcoregames/config/HGConfig.java
+++ b/src/main/java/de/hglabor/plugins/hardcoregames/config/HGConfig.java
@@ -31,6 +31,8 @@ public class HGConfig {
         plugin.getConfig().addDefault(ConfigKeys.SERVER_PING, true);
         plugin.getConfig().addDefault(ConfigKeys.SWORD_DAMAGE_NERF, 0.65);
         plugin.getConfig().addDefault(ConfigKeys.OTHER_TOOLS_DAMAGE_NERF, 0.2);
+        plugin.getConfig().addDefault(ConfigKeys.MOOSHROOM_COW_NERF_MAXSOUPSFROMCOW, 27);
+        plugin.getConfig().addDefault(ConfigKeys.MOOSHROOM_COW_NERF_SOUPSINADDITION, 2);
         plugin.getConfig().options().copyDefaults(true);
         plugin.saveConfig();
     }

--- a/src/main/java/de/hglabor/plugins/hardcoregames/config/HGConfig.java
+++ b/src/main/java/de/hglabor/plugins/hardcoregames/config/HGConfig.java
@@ -31,8 +31,8 @@ public class HGConfig {
         plugin.getConfig().addDefault(ConfigKeys.SERVER_PING, true);
         plugin.getConfig().addDefault(ConfigKeys.SWORD_DAMAGE_NERF, 0.65);
         plugin.getConfig().addDefault(ConfigKeys.OTHER_TOOLS_DAMAGE_NERF, 0.2);
-        plugin.getConfig().addDefault(ConfigKeys.MOOSHROOM_COW_NERF_MAXSOUPSFROMCOW, 27);
-        plugin.getConfig().addDefault(ConfigKeys.MOOSHROOM_COW_NERF_SOUPSINADDITION, 2);
+        plugin.getConfig().addDefault(ConfigKeys.MOOSHROOM_COW_NERF_MAX_SOUPS_FROM_COW, 27);
+        plugin.getConfig().addDefault(ConfigKeys.MOOSHROOM_COW_NERF_COMBAT_MULTIPLIER, 2);
         plugin.getConfig().options().copyDefaults(true);
         plugin.saveConfig();
     }

--- a/src/main/java/de/hglabor/plugins/hardcoregames/game/mechanics/MooshroomCowNerf.java
+++ b/src/main/java/de/hglabor/plugins/hardcoregames/game/mechanics/MooshroomCowNerf.java
@@ -1,5 +1,8 @@
 package de.hglabor.plugins.hardcoregames.game.mechanics;
 
+import com.google.common.collect.ImmutableMap;
+import de.hglabor.plugins.hardcoregames.config.ConfigKeys;
+import de.hglabor.plugins.hardcoregames.config.HGConfig;
 import org.bukkit.Material;
 import org.bukkit.Particle;
 import org.bukkit.Sound;
@@ -17,10 +20,13 @@ import java.util.UUID;
 
 public class MooshroomCowNerf implements Listener {
 
-    private final HashMap<UUID, Integer> cows = new HashMap<>();
+    private final HashMap<UUID, Integer> cows;
 
-    // 3 bars... 1 inventory without the hotbar
-    private final int maxSoupsFromCow = 3*9; // could be a config setting, anyways its a good amount
+    public MooshroomCowNerf() {
+        this.cows = new HashMap<>();
+    }
+
+    private final int maxSoupsFromCow = HGConfig.getInteger(ConfigKeys.MOOSHROOM_COW_NERF_MAXSOUPSFROMCOW);
 
     @EventHandler
     public void onRightclickMooshroomCow(PlayerInteractEntityEvent event) {
@@ -42,9 +48,8 @@ public class MooshroomCowNerf implements Listener {
             HGPlayer hgPlayer = PlayerList.INSTANCE.getKitPlayer(player);
 
             int amount = 1;
-            // players in combat can get a maximum of 9 soups
             if (hgPlayer.isInCombat)
-                amount = 3;
+                amount += HGConfig.getInteger(ConfigKeys.MOOSHROOM_COW_NERF_SOUPSINADDITION);
 
             cows.put(entityUUID, cows.get(entityUUID) == null ? 0 : cows.get(entityUUID) + amount);
 
@@ -61,11 +66,10 @@ public class MooshroomCowNerf implements Listener {
 
                 cows.remove(entityUUID);
             } else if ((maxSoupsFromCow - soupsGiven) % 10 == 0) {
-                // message could be localised but these tokens oof
-                player.sendMessage("Du kannst die §bKuh §rnoch §b" + (maxSoupsFromCow - soupsGiven) + " §rmal melken!");
+                // original: player.sendMessage("Du kannst die §bKuh §rnoch §b" + (maxSoupsFromCow - soupsGiven) + " §rmal melken!");
+                // Message: "Anzahl der noch verfügbaren Milch: "
+                player.sendMessage(Localization.INSTANCE.getMessage("mushroomcownerf.timesLeftToMilk") + " " + (maxSoupsFromCow - soupsGiven));
             }
         }
-
     }
-
 }

--- a/src/main/java/de/hglabor/plugins/hardcoregames/game/mechanics/MooshroomCowNerf.java
+++ b/src/main/java/de/hglabor/plugins/hardcoregames/game/mechanics/MooshroomCowNerf.java
@@ -1,0 +1,68 @@
+package de.hglabor.plugins.hardcoregames.game.mechanics;
+
+import org.bukkit.Material;
+import org.bukkit.Particle;
+import org.bukkit.Sound;
+import org.bukkit.SoundCategory;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.MushroomCow;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerInteractEntityEvent;
+import org.bukkit.inventory.EquipmentSlot;
+
+import java.util.HashMap;
+import java.util.UUID;
+
+public class MooshroomCowNerf implements Listener {
+
+    private final HashMap<UUID, Integer> cows = new HashMap<>();
+
+    // 3 bars... 1 inventory without the hotbar
+    private final int maxSoupsFromCow = 3*9; // could be a config setting, anyways its a good amount
+
+    @EventHandler
+    public void onRightclickMooshroomCow(PlayerInteractEntityEvent event) {
+
+        // the event fires for each hand, but we dont want our code to be executed twice
+        if (event.getHand() == EquipmentSlot.OFF_HAND) return;
+
+        if (event.getRightClicked().getType() != EntityType.MUSHROOM_COW) return;
+
+        // might not work - couldn't test it because of these tokens damn
+        HGPlayer hgPlayer = PlayerList.INSTANCE.getKitPlayer(player);
+        if (hgPlayer.isInCombat)
+            return;
+
+        MushroomCow entity = (MushroomCow) event.getRightClicked();
+        Player player = event.getPlayer();
+
+        if (player.getInventory().getItemInMainHand().getType() == Material.BOWL ||
+                player.getInventory().getItemInOffHand().getType() == Material.BOWL) {
+
+            UUID entityUUID = entity.getUniqueId();
+
+            cows.put(entityUUID, cows.get(entityUUID) == null ? 0 : cows.get(entityUUID) + 1);
+
+            int soupsGiven = cows.get(entityUUID);
+
+            if (soupsGiven >= maxSoupsFromCow) {
+                // visual & sound
+                player.getWorld().spawnParticle(Particle.CRIMSON_SPORE,
+                        entity.getLocation().add(0.0, 0.5, 0.0), 15, 0.1, 0.2, 0.1, 1.2);
+                player.playSound(player.getLocation(), Sound.ENTITY_EVOKER_PREPARE_SUMMON, SoundCategory.AMBIENT, 1, 1);
+
+                entity.remove();
+                entity.getWorld().spawnEntity(entity.getLocation(), EntityType.COW);
+
+                cows.remove(entityUUID);
+            } else if ((maxSoupsFromCow - soupsGiven) % 10 == 0) {
+                // message could be localised but these tokens oof
+                player.sendMessage("rDu kannst die §bKuh §rnoch §b" + (maxSoupsFromCow - soupsGiven) + " §rmal melken!");
+            }
+        }
+
+    }
+
+}

--- a/src/main/java/de/hglabor/plugins/hardcoregames/game/mechanics/MooshroomCowNerf.java
+++ b/src/main/java/de/hglabor/plugins/hardcoregames/game/mechanics/MooshroomCowNerf.java
@@ -49,6 +49,7 @@ public class MooshroomCowNerf implements Listener {
             HGPlayer hgPlayer = PlayerList.INSTANCE.getPlayer(player);
             int milkedSoups = cows.getOrDefault(entityUUID, 0);
             milkedSoups += hgPlayer.isInCombat() ? 1 : COMBAT_MULTIPLIER;
+            cows.put(entityUUID, milkedSoups);
 
             if ((MAX_SOUPS_FROM_COW - milkedSoups) % 10 == 0 || milkedSoups < 5) {
                 player.sendMessage(Localization.INSTANCE.getMessage("mushroomcownerf.timesLeftToMilk",

--- a/src/main/java/de/hglabor/plugins/hardcoregames/game/mechanics/MooshroomCowNerf.java
+++ b/src/main/java/de/hglabor/plugins/hardcoregames/game/mechanics/MooshroomCowNerf.java
@@ -62,7 +62,7 @@ public class MooshroomCowNerf implements Listener {
                 cows.remove(entityUUID);
             } else if ((maxSoupsFromCow - soupsGiven) % 10 == 0) {
                 // message could be localised but these tokens oof
-                player.sendMessage("rDu kannst die §bKuh §rnoch §b" + (maxSoupsFromCow - soupsGiven) + " §rmal melken!");
+                player.sendMessage("Du kannst die §bKuh §rnoch §b" + (maxSoupsFromCow - soupsGiven) + " §rmal melken!");
             }
         }
 

--- a/src/main/java/de/hglabor/plugins/hardcoregames/game/mechanics/MooshroomCowNerf.java
+++ b/src/main/java/de/hglabor/plugins/hardcoregames/game/mechanics/MooshroomCowNerf.java
@@ -3,6 +3,10 @@ package de.hglabor.plugins.hardcoregames.game.mechanics;
 import com.google.common.collect.ImmutableMap;
 import de.hglabor.plugins.hardcoregames.config.ConfigKeys;
 import de.hglabor.plugins.hardcoregames.config.HGConfig;
+import de.hglabor.plugins.hardcoregames.player.HGPlayer;
+import de.hglabor.plugins.hardcoregames.player.PlayerList;
+import de.hglabor.utils.localization.Localization;
+import de.hglabor.utils.noriskutils.ChatUtils;
 import org.bukkit.Material;
 import org.bukkit.Particle;
 import org.bukkit.Sound;
@@ -19,56 +23,45 @@ import java.util.HashMap;
 import java.util.UUID;
 
 public class MooshroomCowNerf implements Listener {
-
     private final HashMap<UUID, Integer> cows;
+    private final int MAX_SOUPS_FROM_COW;
+    private final int COMBAT_MULTIPLIER;
 
     public MooshroomCowNerf() {
         this.cows = new HashMap<>();
+        this.MAX_SOUPS_FROM_COW = HGConfig.getInteger(ConfigKeys.MOOSHROOM_COW_NERF_MAX_SOUPS_FROM_COW);
+        this.COMBAT_MULTIPLIER = HGConfig.getInteger(ConfigKeys.MOOSHROOM_COW_NERF_COMBAT_MULTIPLIER);
     }
-
-    private final int maxSoupsFromCow = HGConfig.getInteger(ConfigKeys.MOOSHROOM_COW_NERF_MAXSOUPSFROMCOW);
 
     @EventHandler
     public void onRightclickMooshroomCow(PlayerInteractEntityEvent event) {
-
         // the event fires for each hand, but we dont want our code to be executed twice
-        if (event.getHand() == EquipmentSlot.OFF_HAND) return;
-
-        if (event.getRightClicked().getType() != EntityType.MUSHROOM_COW) return;
-
+        if (event.getHand() == EquipmentSlot.OFF_HAND) {
+            return;
+        }
+        if (event.getRightClicked().getType() != EntityType.MUSHROOM_COW) {
+            return;
+        }
         MushroomCow entity = (MushroomCow) event.getRightClicked();
         Player player = event.getPlayer();
-
-        if (player.getInventory().getItemInMainHand().getType() == Material.BOWL ||
-                player.getInventory().getItemInOffHand().getType() == Material.BOWL) {
-
+        if (player.getInventory().getItemInMainHand().getType() == Material.BOWL) {
             UUID entityUUID = entity.getUniqueId();
-
-            // might not work - couldn't test it because of these tokens damn
             HGPlayer hgPlayer = PlayerList.INSTANCE.getPlayer(player);
+            int milkedSoups = cows.getOrDefault(entityUUID, 0);
+            milkedSoups += hgPlayer.isInCombat() ? 1 : COMBAT_MULTIPLIER;
 
-            int amount = 1;
-            if (hgPlayer.isInCombat)
-                amount += HGConfig.getInteger(ConfigKeys.MOOSHROOM_COW_NERF_SOUPSINADDITION);
+            if ((MAX_SOUPS_FROM_COW - milkedSoups) % 10 == 0 || milkedSoups < 5) {
+                player.sendMessage(Localization.INSTANCE.getMessage("mushroomcownerf.timesLeftToMilk",
+                        ImmutableMap.of("soupsLeft", String.valueOf(MAX_SOUPS_FROM_COW - milkedSoups)),
+                        ChatUtils.getPlayerLocale(player)));
+            }
 
-            cows.put(entityUUID, cows.getOrDefault(entityUUID, 0) + amount);
-
-            int soupsGiven = cows.get(entityUUID);
-
-            if (soupsGiven >= maxSoupsFromCow) {
-                // visual & sound
-                player.getWorld().spawnParticle(Particle.CRIMSON_SPORE,
-                        entity.getLocation().add(0.0, 0.5, 0.0), 15, 0.1, 0.2, 0.1, 1.2);
+            if (milkedSoups >= MAX_SOUPS_FROM_COW) {
+                player.getWorld().spawnParticle(Particle.CRIMSON_SPORE, entity.getLocation().clone().add(0.0, 0.5, 0.0), 15, 0.1, 0.2, 0.1, 1.2);
                 player.playSound(player.getLocation(), Sound.ENTITY_EVOKER_PREPARE_SUMMON, SoundCategory.AMBIENT, 1, 1);
-
                 entity.remove();
                 entity.getWorld().spawnEntity(entity.getLocation(), EntityType.COW);
-
                 cows.remove(entityUUID);
-            } else if ((maxSoupsFromCow - soupsGiven) % 10 == 0) {
-                // original: player.sendMessage("Du kannst die §bKuh §rnoch §b" + (maxSoupsFromCow - soupsGiven) + " §rmal melken!");
-                // Message: "Anzahl der noch verfügbaren Milch: "
-                player.sendMessage(Localization.INSTANCE.getMessage("mushroomcownerf.timesLeftToMilk") + " " + (maxSoupsFromCow - soupsGiven));
             }
         }
     }

--- a/src/main/java/de/hglabor/plugins/hardcoregames/game/mechanics/MooshroomCowNerf.java
+++ b/src/main/java/de/hglabor/plugins/hardcoregames/game/mechanics/MooshroomCowNerf.java
@@ -51,7 +51,7 @@ public class MooshroomCowNerf implements Listener {
             if (hgPlayer.isInCombat)
                 amount += HGConfig.getInteger(ConfigKeys.MOOSHROOM_COW_NERF_SOUPSINADDITION);
 
-            cows.put(entityUUID, cows.get(entityUUID) == null ? 0 : cows.get(entityUUID) + amount);
+            cows.put(entityUUID, cows.getOrDefault(entityUUID, 0) + amount);
 
             int soupsGiven = cows.get(entityUUID);
 

--- a/src/main/java/de/hglabor/plugins/hardcoregames/game/mechanics/MooshroomCowNerf.java
+++ b/src/main/java/de/hglabor/plugins/hardcoregames/game/mechanics/MooshroomCowNerf.java
@@ -45,7 +45,7 @@ public class MooshroomCowNerf implements Listener {
             UUID entityUUID = entity.getUniqueId();
 
             // might not work - couldn't test it because of these tokens damn
-            HGPlayer hgPlayer = PlayerList.INSTANCE.getKitPlayer(player);
+            HGPlayer hgPlayer = PlayerList.INSTANCE.getPlayer(player);
 
             int amount = 1;
             if (hgPlayer.isInCombat)

--- a/src/main/java/de/hglabor/plugins/hardcoregames/game/mechanics/MooshroomCowNerf.java
+++ b/src/main/java/de/hglabor/plugins/hardcoregames/game/mechanics/MooshroomCowNerf.java
@@ -30,11 +30,6 @@ public class MooshroomCowNerf implements Listener {
 
         if (event.getRightClicked().getType() != EntityType.MUSHROOM_COW) return;
 
-        // might not work - couldn't test it because of these tokens damn
-        HGPlayer hgPlayer = PlayerList.INSTANCE.getKitPlayer(player);
-        if (hgPlayer.isInCombat)
-            return;
-
         MushroomCow entity = (MushroomCow) event.getRightClicked();
         Player player = event.getPlayer();
 
@@ -43,7 +38,15 @@ public class MooshroomCowNerf implements Listener {
 
             UUID entityUUID = entity.getUniqueId();
 
-            cows.put(entityUUID, cows.get(entityUUID) == null ? 0 : cows.get(entityUUID) + 1);
+            // might not work - couldn't test it because of these tokens damn
+            HGPlayer hgPlayer = PlayerList.INSTANCE.getKitPlayer(player);
+
+            int amount = 1;
+            // players in combat can get a maximum of 9 soups
+            if (hgPlayer.isInCombat)
+                amount = 3;
+
+            cows.put(entityUUID, cows.get(entityUUID) == null ? 0 : cows.get(entityUUID) + amount);
 
             int soupsGiven = cows.get(entityUUID);
 

--- a/src/main/java/de/hglabor/plugins/hardcoregames/game/mechanics/SoupHealing.java
+++ b/src/main/java/de/hglabor/plugins/hardcoregames/game/mechanics/SoupHealing.java
@@ -1,47 +1,71 @@
 package de.hglabor.plugins.hardcoregames.game.mechanics;
 
-import de.hglabor.plugins.kitapi.kit.config.KitMetaData;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractEvent;
-import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 
 public class SoupHealing implements Listener {
-    public static final List<Material> SOUP_MATERIAL = Arrays.asList(Material.MUSHROOM_STEW, Material.SUSPICIOUS_STEW);
+    public static final List<Material> SOUP_MATERIAL = Arrays.asList(
+            Material.MUSHROOM_STEW,
+            Material.BEETROOT_SOUP,
+            Material.RABBIT_STEW,
+            Material.SUSPICIOUS_STEW
+    );
+
+    public static final HashMap<Material, Integer> RESTORED_FOOD = new HashMap<>() {{
+        put(Material.MUSHROOM_STEW, 6);
+        put(Material.BEETROOT_SOUP, 6);
+        put(Material.RABBIT_STEW, 10);
+    }};
+
+    public static final HashMap<Material, Float> RESTORED_SATURATION = new HashMap<>() {{
+        put(Material.MUSHROOM_STEW, 7.2f);
+        put(Material.BEETROOT_SOUP, 7.2f);
+        put(Material.RABBIT_STEW, 12f);
+    }};
 
     @EventHandler
     public void onRightClickSoup(PlayerInteractEvent event) {
-        Player player = event.getPlayer();
-        if (event.getAction() == Action.LEFT_CLICK_AIR) {
-            return;
-        }
-        ItemStack itemStack = event.getItem();
-        if (itemStack == null) {
-            return;
-        }
-        if (event.hasItem() && SOUP_MATERIAL.contains(event.getMaterial())) {
-            if (event.getHand() == EquipmentSlot.OFF_HAND) {
-                return;
+
+        if (event.getAction() == Action.LEFT_CLICK_AIR) return;
+
+        Player p = event.getPlayer();
+
+        if (p.getHealth() >= p.getHealthScale() && p.getFoodLevel() >= 20) return;
+
+        ItemStack interactItem = p.getInventory().getItem(event.getHand());
+
+        if (SOUP_MATERIAL.contains(interactItem.getType())) {
+
+            Material interactItemType = interactItem.getType();
+
+            int healing = 7;
+            if (interactItem.hasItemMeta() &&
+                    event.getItem().getItemMeta().getDisplayName().equalsIgnoreCase(KitMetaData.SPIT_SOUP.getKey()))
+                healing = 3;
+
+            boolean ifConsume = false;
+
+            if (p.getHealth() < p.getHealthScale()) {
+                p.setHealth(Math.min(p.getHealth() + healing, p.getHealthScale()));
+                ifConsume = true;
+            } else if (p.getFoodLevel() < 20) {
+                p.setFoodLevel(Math.min(p.getFoodLevel() + RESTORED_FOOD.get(interactItemType), 20));
+                p.setSaturation(Math.min(p.getSaturation() + RESTORED_SATURATION.get(interactItemType), p.getFoodLevel()));
+                ifConsume = true;
             }
-            int amountToHeal = 7;
-            if (itemStack.hasItemMeta() && event.getItem().getItemMeta().getDisplayName().equalsIgnoreCase(KitMetaData.SPIT_SOUP.getKey())) {
-                amountToHeal = 3;
-            }
-            if (player.getHealth() < player.getMaxHealth()) {
-                player.setHealth(Math.min(player.getHealth() + amountToHeal, player.getMaxHealth()));
-                player.getInventory().setItemInMainHand(new ItemStack(Material.BOWL));
-            } else if (player.getFoodLevel() < 20) {
-                player.setFoodLevel(player.getFoodLevel() + 6);
-                player.setSaturation(player.getSaturation() + 7);
-                player.getInventory().setItemInMainHand(new ItemStack(Material.BOWL));
-            }
+
+            if (ifConsume) interactItem.setType(Material.BOWL);
+
         }
+
     }
 }


### PR DESCRIPTION
A mushroom cow can be milked 3*9 times before transforming into a normal cow.
Players in combat let the counter for soups given rise faster.