### PR TITLE
Off-Hand check for Mushroom Cow Nerf

### DIFF
--- a/src/main/java/de/hglabor/plugins/hardcoregames/game/mechanics/MooshroomCowNerf.java
+++ b/src/main/java/de/hglabor/plugins/hardcoregames/game/mechanics/MooshroomCowNerf.java
@@ -44,7 +44,8 @@ public class MooshroomCowNerf implements Listener {
         }
         MushroomCow entity = (MushroomCow) event.getRightClicked();
         Player player = event.getPlayer();
-        if (player.getInventory().getItemInMainHand().getType() == Material.BOWL) {
+        if (player.getInventory().getItemInMainHand().getType() == Material.BOWL ||
+                player.getInventory().getItemInOffHand().getType() == Material.BOWL) {
             UUID entityUUID = entity.getUniqueId();
             HGPlayer hgPlayer = PlayerList.INSTANCE.getPlayer(player);
             int milkedSoups = cows.getOrDefault(entityUUID, 0);


### PR DESCRIPTION
This is important!
If the Off-Hand is unchecked, a bowl in the Off-hand can be used to milk the mushroom cow indefinitely!